### PR TITLE
Specify commit of gz_ros2_control dependency

### DIFF
--- a/rosbot_xl/rosbot_xl_simulation.repos
+++ b/rosbot_xl/rosbot_xl_simulation.repos
@@ -3,7 +3,8 @@ repositories:
     type: git
     url: https://github.com/ros-controls/gz_ros2_control.git
     # on branch humble hardware isn't activated
-    version: master
+    # recently on master API breaking change was introduced, it is necessay to use commit before this change
+    version: b296ff2f5c3758b637a70bd496fe6ed875ab03ce
 
   husarion/gazebo_worlds:
     type: git


### PR DESCRIPTION
bump::patch
Recently api breaking change was introduced on master and it no longer builds on humble
